### PR TITLE
added remove-from-group action

### DIFF
--- a/lib/rewards.js
+++ b/lib/rewards.js
@@ -22,6 +22,19 @@ rewards.get = function(rewards, callback) {
 				]
 			},
 			{
+                                "rid": "essentials/remove-from-group",
+                                "name": "Remove from Group",
+                                "inputs": [
+                                        {
+                                                "type": "select",
+                                                "name": "groupname",
+                                                "label": "Group Name:",
+                                                "values": groups
+                                        }
+                                ]
+                        },
+
+			{
 				"rid": "essentials/alert-user",
 				"name": "Send alert message",
 				"inputs": [

--- a/plugin.json
+++ b/plugin.json
@@ -15,6 +15,9 @@
 			"hook": "action:rewards.award:essentials/add-to-group", "method": "rewards.addToGroup"
 		},
 		{
+                        "hook": "action:rewards.award:essentials/remove-from-group", "method": "rewards.removeFromGroup"
+                },
+		{
 			"hook": "action:rewards.award:essentials/alert-user", "method": "rewards.alertUser"
 		},
 		{


### PR DESCRIPTION
It think it is a usefull enhancement have the possibility to remove users from a group based on their reputatation or number of posts.

Possible usage:
- remove user from newbies group
- restrict users with negative reputation (= spammer?) to given groups 